### PR TITLE
Fix reply root reference

### DIFF
--- a/autoReply.js
+++ b/autoReply.js
@@ -201,10 +201,15 @@ export async function autoReply() {
         }
         console.log(`[Réponse] Génération d'une réponse à : ${truncatedText}`);
         let reply = await generateReplyText(truncatedText, lang === 'fra' ? 'fr' : 'en');
+        reply = `@${author.handle} ${reply}`;
+        if (reply.length > 300) reply = reply.substring(0, 300);
         console.log(`[Réponse] Réponse générée : ${reply}`);
+        const rootRef = record?.reply?.root
+          ? { cid: record.reply.root.cid, uri: record.reply.root.uri }
+          : { cid: post.cid, uri: post.uri };
         await agent.post({
           reply: {
-            root: { cid: post.cid, uri: post.uri },
+            root: rootRef,
             parent: { cid: post.cid, uri: post.uri }
           },
           text: reply,


### PR DESCRIPTION
## Summary
- reply object now uses existing root reference if available
- prefix auto-generated replies with author handle
- trim replies to 300 characters without slice

## Testing
- `npm install`
- `node testAutoReply.js` *(fails: BLUESKY_HANDLE et BLUESKY_PASSWORD doivent être définis)*

------
https://chatgpt.com/codex/tasks/task_e_686f58292e708330b08fa3bbc75fa0e2