### PR TITLE
Fix autoReply root reference

### DIFF
--- a/autoReply.js
+++ b/autoReply.js
@@ -220,9 +220,13 @@ export async function autoReply() {
           break;
         }
         
+        const rootRef = record?.reply?.root
+          ? { cid: record.reply.root.cid, uri: record.reply.root.uri }
+          : { cid: post.cid, uri: post.uri };
+
         await agent.post({
           reply: {
-            root: { cid: post.cid, uri: post.uri },
+            root: rootRef,
             parent: { cid: post.cid, uri: post.uri }
           },
           text: reply,


### PR DESCRIPTION
## Summary
- fix reply root reference when posting replies to ensure thread context is kept

## Testing
- `npm install`
- `node testAutoReply.js` *(fails: BLUESKY_HANDLE and BLUESKY_PASSWORD must be defined in .env)*

------
https://chatgpt.com/codex/tasks/task_e_686f69d8ac348330aeeb01da978fa704