### PR TITLE
Use original root for replies

### DIFF
--- a/autoReply.js
+++ b/autoReply.js
@@ -212,9 +212,12 @@ export async function autoReply() {
         console.log(`[Réponse] Génération d'une réponse à : ${truncatedText}`);
         let reply = await generateReplyText(truncatedText, lang === 'fra' ? 'fr' : 'en');
         console.log(`[Réponse] Réponse générée : ${reply}`);
+        const rootRef = record?.reply?.root
+          ? { cid: record.reply.root.cid, uri: record.reply.root.uri }
+          : { cid: post.cid, uri: post.uri };
         await agent.post({
           reply: {
-            root: { cid: post.cid, uri: post.uri },
+            root: rootRef,
             parent: { cid: post.cid, uri: post.uri }
           },
           text: reply,


### PR DESCRIPTION
## Summary
- handle reply roots correctly in `autoReply`

## Testing
- `node --check autoReply.js`

------
https://chatgpt.com/codex/tasks/task_e_686f69f873d08330b4c8e2c44deb8be5