### PR TITLE
Use thread root when replying

### DIFF
--- a/autoReply.js
+++ b/autoReply.js
@@ -199,9 +199,14 @@ export async function autoReply() {
         console.log(`[Réponse] Génération d'une réponse à : ${truncatedText}`);
         let reply = await generateReplyText(truncatedText, lang === 'fra' ? 'fr' : 'en');
         console.log(`[Réponse] Réponse générée : ${reply}`);
+
+        const rootRef = record?.reply?.root
+          ? { cid: record.reply.root.cid, uri: record.reply.root.uri }
+          : { cid: post.cid, uri: post.uri };
+
         await agent.post({
           reply: {
-            root: { cid: post.cid, uri: post.uri },
+            root: rootRef,
             parent: { cid: post.cid, uri: post.uri }
           },
           text: reply,


### PR DESCRIPTION
## Summary
- adjust autoReply to reply to the root post in a thread when available

## Testing
- `node --check autoReply.js`
- `npm install`
- `node testAutoReply.js` *(fails: BLUESKY_HANDLE and BLUESKY_PASSWORD must be defined)*

------
https://chatgpt.com/codex/tasks/task_e_686f6a1217a4833082c2bc0eb840f2f8