### PR TITLE
Add daily news topic fetcher and integrate into text generation and scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Bot Bluesky complet en Node.js/ESM pour générer, poster, liker, suivre et rép
 ## Fonctionnalités
 - **Génération d’images memes Clippy** via l’API Hugging Face (Stable Diffusion)
 - **Génération de textes posts et replies** via DeepSeek ou OpenAI (GPT)
+- **Récupération automatique quotidienne des grosses actualités et de quelques sources tech** puis génération de posts qui gardent la personnalité de Joe
 - **Publication automatique** sur Bluesky (texte + image)
 - **Like et follow automatiques** de comptes ciblés
 - **Réponses automatiques** aux posts #CLIPPY
@@ -60,6 +61,12 @@ BLUESKY_HANDLE=ton.handle.bsky.social
 BLUESKY_PASSWORD=ton_mot_de_passe
 HUGGINGFACE_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DEEPSEEK_KEY=ds_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # ou OPENAI_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEWS_SOURCES=https://feeds.bbci.co.uk/news/rss.xml,https://www.npr.org/rss/rss.php?id=1001       # optionnel : gros flux RSS généralistes à relever chaque jour
+NEWS_TECH_SOURCES=https://feeds.bbci.co.uk/news/technology/rss.xml,https://techcrunch.com/feed/  # optionnel : quelques flux tech en complément
+NEWS_CACHE_PATH=./analytics/current-news-topics.json                                           # optionnel : cache quotidien des sujets
+NEWS_TIMEOUT_MS=5000                                                                          # optionnel : délai max par source
+NEWS_MAX_ITEMS=30                                                                             # optionnel : nombre max de sujets en cache
+NEWS_MAX_TECH_ITEMS=6                                                                         # optionnel : nombre max de sujets tech dans le cache quotidien
 ```
 
 ---
@@ -70,7 +77,8 @@ DEEPSEEK_KEY=ds_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # ou OPENAI_KEY=sk-xxxxxxxxxxx
 BlueBot/
 ├── bluesky.js          # Gestion de l’agent Bluesky & upload image
 ├── generateImage.js    # Génération d’image Clippy via Hugging Face
-├── generateText.js     # Génération de texte (post/reply) via IA
+├── newsTopics.js      # Récupération quotidienne/cache des sources d’actualité
+├── generateText.js     # Utilisation des sujets d’actualité + génération de texte (post/reply) via IA
 ├── postImage.js        # Publication d’un post Clippy (texte + image)
 ├── likeAndFollow.js    # Like & follow automatiques
 ├── autoReply.js        # Réponses automatiques aux posts #CLIPPY
@@ -110,9 +118,10 @@ node scheduler.js
 ```
 
 Le scheduler planifie automatiquement :
-- 3 posts Clippy par jour (9h, 15h, 21h)
-- 1 session like/follow à 10h
-- 1 session auto-reply à 12h
+- une récupération automatique quotidienne des sources d’actualité (par défaut à 6h) avec cache local
+- des posts texte à heures fixes ; chaque post pioche dans le cache du jour, principalement composé des grosses news avec quelques sujets tech
+- des sessions like/follow ciblées
+- des sessions auto-reply
 
 ---
 

--- a/generateText.js
+++ b/generateText.js
@@ -7,6 +7,7 @@
 
 import axios from 'axios'
 import dotenv from 'dotenv'
+import { getCurrentNewsTopic } from './newsTopics.js'
 
 dotenv.config()
 
@@ -27,7 +28,6 @@ const API_URL = provider === 'deepseek'
     : null;
 
 const MODEL = provider === 'deepseek' ? 'deepseek-v4-flash' : 'gpt-3.5-turbo';
-
 
 // ---------------------------------------------------------------------
 async function callGeminiApi(messages, maxTokens = 30) {
@@ -77,6 +77,7 @@ const SYSTEM_POST = `You are Joe, a French blockchain developer (Solidity, TypeS
  * @returns {Promise<string>}
  */
 export async function generateTrombonePostText() {
+  const currentTopic = await getCurrentNewsTopic();
   // Liste de thèmes variés pour un développeur blockchain français cherchant à contribuer à des projets
   // Thèmes adaptés à la première personne :
   const topics = [
@@ -91,7 +92,9 @@ export async function generateTrombonePostText() {
     "My consensus algo: unanimous laughter at my own jokes",
     "My economic thesis treats humor as reserve currency"
   ];
-  const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+  const randomTopic = currentTopic
+    ? `Current news topic: ${currentTopic.title} (source: ${currentTopic.source}).`
+    : topics[Math.floor(Math.random() * topics.length)];
   // 40% posts très courts, 60% posts moyens/longs
   const isShort = Math.random() < 0.8;
   let userPrompt;
@@ -113,6 +116,7 @@ export async function generateTrombonePostText() {
 }
 
 export async function generatePostText() {
+  const currentTopic = await getCurrentNewsTopic();
   // Liste de topics/moods pour varier les posts - maintenant avec expertise économique/tech et humour
   // Topics adaptés à la première personne :
   const topics = [
@@ -128,12 +132,14 @@ export async function generatePostText() {
     "Networking IRL and on-chain—sometimes simultaneously"
   ];
   // Choix aléatoire d'un topic
-  const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+  const randomTopic = currentTopic
+    ? `Current news topic: ${currentTopic.title} (source: ${currentTopic.source}).`
+    : topics[Math.floor(Math.random() * topics.length)];
   // Tirage aléatoire pour la longueur du post (80% court, 20% moyen/long)
   const isShort = Math.random() < 0.5;
   let userPrompt;
   if (isShort) {
-    userPrompt = `${randomTopic}\nWrite a new original, authentic-sounding post for a blockchain developer visiting Silicon Valley. It should feel like a real human thought, not a polished marketing message. It MUST be extremely short (1-2 lines, under 10 words) and written in the first person (\"I\", \"my\", \"me\").only plain text, in English. No markdown, no emojis.`;
+    userPrompt = `${randomTopic}\nWrite a new original, authentic-sounding post for a blockchain developer visiting Silicon Valley. It should feel like a real human thought, not a polished marketing message. It MUST be extremely short (1-2 lines, under 10 words) and written in the first person (\"I\", \"my\", \"me\"). Only plain text, in English. No markdown, no emojis.`;
   } else {
     userPrompt = `${randomTopic}\nWrite a new original post that sounds like a real human thought from a French blockchain developer named Joe visiting Silicon Valley. It should express authentic human qualities - perhaps a moment of insight, frustration, joy, curiosity, or reflection. It MUST be written in the first person (\"I\", \"my\", \"me\") with occasional hints of your French background or perspective. Only plain text, in English. No markdown, no emojis.`;
   }

--- a/newsTopics.js
+++ b/newsTopics.js
@@ -1,0 +1,145 @@
+// newsTopics.js
+// Récupération quotidienne automatique des sujets d'actualité pour BlueBot.
+
+import axios from 'axios';
+import fs from 'fs/promises';
+import path from 'path';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const DEFAULT_MAJOR_NEWS_SOURCES = [
+  'https://feeds.bbci.co.uk/news/rss.xml',
+  'https://www.npr.org/rss/rss.php?id=1001',
+  'https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml',
+  'https://www.theguardian.com/world/rss',
+];
+
+const DEFAULT_TECH_NEWS_SOURCES = [
+  'https://feeds.bbci.co.uk/news/technology/rss.xml',
+  'https://techcrunch.com/feed/',
+  'https://www.wired.com/feed/rss',
+];
+
+function parseSources(value, fallback) {
+  return (value || fallback.join(','))
+    .split(',')
+    .map(source => source.trim())
+    .filter(Boolean);
+}
+
+const MAJOR_NEWS_SOURCES = parseSources(process.env.NEWS_SOURCES, DEFAULT_MAJOR_NEWS_SOURCES);
+const TECH_NEWS_SOURCES = parseSources(process.env.NEWS_TECH_SOURCES, DEFAULT_TECH_NEWS_SOURCES);
+const NEWS_CACHE_PATH = process.env.NEWS_CACHE_PATH || './analytics/current-news-topics.json';
+const NEWS_TIMEOUT_MS = Number(process.env.NEWS_TIMEOUT_MS || 5000);
+const NEWS_MAX_ITEMS = Number(process.env.NEWS_MAX_ITEMS || 30);
+const NEWS_MAX_TECH_ITEMS = Number(process.env.NEWS_MAX_TECH_ITEMS || 6);
+
+function decodeXml(value = '') {
+  return value
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function hostnameFromUrl(url, fallback = 'news source') {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return fallback;
+  }
+}
+
+function firstTagValue(xml, tagName) {
+  return xml.match(new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)<\\/${tagName}>`, 'i'))?.[1] || '';
+}
+
+function parseRssItems(xml, feedUrl, category) {
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)]
+    .map(([, item]) => {
+      const link = decodeXml(firstTagValue(item, 'link'));
+      return {
+        title: decodeXml(firstTagValue(item, 'title')),
+        source: hostnameFromUrl(link || feedUrl),
+        category,
+        url: link,
+        pubDate: decodeXml(firstTagValue(item, 'pubDate')),
+        fetchedAt: new Date().toISOString(),
+      };
+    })
+    .filter(topic => topic.title);
+}
+
+async function fetchSource(source, category) {
+  const { data } = await axios.get(source, {
+    timeout: NEWS_TIMEOUT_MS,
+    headers: { 'User-Agent': 'BlueBot/1.0 (+https://bsky.app)' },
+  });
+  return parseRssItems(data, source, category);
+}
+
+async function readCachedTopics() {
+  try {
+    const raw = await fs.readFile(NEWS_CACHE_PATH, 'utf8');
+    const cache = JSON.parse(raw);
+    return Array.isArray(cache?.topics) ? cache : { refreshedAt: null, topics: [] };
+  } catch {
+    return { refreshedAt: null, topics: [] };
+  }
+}
+
+async function writeCachedTopics(topics) {
+  await fs.mkdir(path.dirname(NEWS_CACHE_PATH), { recursive: true });
+  await fs.writeFile(
+    NEWS_CACHE_PATH,
+    `${JSON.stringify({ refreshedAt: new Date().toISOString(), topics }, null, 2)}\n`,
+    'utf8'
+  );
+}
+
+async function fetchTopicGroup(sources, category) {
+  const settledFeeds = await Promise.allSettled(
+    sources.map(source => fetchSource(source, category))
+  );
+  return settledFeeds.flatMap(result => (result.status === 'fulfilled' ? result.value : []));
+}
+
+export async function refreshDailyNewsTopics({ force = false } = {}) {
+  const cache = await readCachedTopics();
+  const refreshedAt = cache.refreshedAt ? new Date(cache.refreshedAt).getTime() : 0;
+
+  if (!force && cache.topics.length > 0 && Date.now() - refreshedAt < ONE_DAY_MS) {
+    return cache.topics;
+  }
+
+  const [majorTopics, techTopics] = await Promise.all([
+    fetchTopicGroup(MAJOR_NEWS_SOURCES, 'major'),
+    fetchTopicGroup(TECH_NEWS_SOURCES, 'tech'),
+  ]);
+
+  const maxTechItems = Math.min(NEWS_MAX_TECH_ITEMS, NEWS_MAX_ITEMS);
+  const maxMajorItems = Math.max(NEWS_MAX_ITEMS - maxTechItems, 0);
+  const topics = [
+    ...majorTopics.slice(0, maxMajorItems),
+    ...techTopics.slice(0, maxTechItems),
+  ];
+
+  if (topics.length > 0) {
+    await writeCachedTopics(topics);
+    return topics;
+  }
+
+  console.warn('[News] Unable to refresh daily news topics; keeping cached topics if available.');
+  return cache.topics;
+}
+
+export async function getCurrentNewsTopic() {
+  const topics = await refreshDailyNewsTopics();
+  if (topics.length === 0) return null;
+  return topics[Math.floor(Math.random() * topics.length)];
+}

--- a/scheduler.js
+++ b/scheduler.js
@@ -6,6 +6,7 @@ const { BlazeJob } = pkg;
 import dotenv from 'dotenv';
 
 import { generateTrombonePostText } from './generateText.js';
+import { refreshDailyNewsTopics } from './newsTopics.js';
 import { likeAndFollowHashtag } from './likeAndFollow.js';
 import { agent, initBluesky } from './bluesky.js';
 
@@ -28,6 +29,24 @@ console.log('=== BlueBot Scheduler started! (Render log test) ===');
 const jobs = new BlazeJob({ dbPath: './clippy-jobs.db' });
 
 const isTest = process.env.NODE_ENV === 'test';
+
+
+// Récupère automatiquement les sources d'actualité une fois par jour avant les posts.
+jobs.schedule(async () => {
+  try {
+    console.log('[BlazeJob] [START] Refresh daily news topics');
+    const topics = await refreshDailyNewsTopics({ force: true });
+    console.log(`[BlazeJob][News] ${topics.length} sujets d'actualité en cache`);
+    console.log('[BlazeJob] [END] Refresh daily news topics');
+  } catch (err) {
+    console.error('[BlazeJob][ERROR] Refresh daily news topics :', err);
+  }
+}, {
+  name: 'Daily News Topic Refresh',
+  runAt: isTest ? inMinutes(1) : nextHour(6),
+  interval: 24 * 60 * 60 * 1000,
+  maxRuns: 3650,
+});
 
 // 3 posts texte courts (sans image) chaque jour à 9h, 13h et 17h
 const postTextHours = [9, 13, 17, 21, 22, 23]; // 3 posts texte par jour


### PR DESCRIPTION
### Motivation
- Add an automated daily news-topic pipeline so generated posts can reference current events and a small set of tech stories.  
- Cache and limit sources to avoid fetching on every post and to keep scheduler-driven posting more topical.  

### Description
- Add `newsTopics.js` which fetches RSS feeds, parses and decodes items, enforces timeouts/limits, caches results to `NEWS_CACHE_PATH`, and exports `refreshDailyNewsTopics` and `getCurrentNewsTopic`.  
- Integrate news topics into `generateText.js` by importing `getCurrentNewsTopic` and optionally injecting a `Current news topic:` prompt when available.  
- Schedule a daily refresh job in `scheduler.js` that calls `refreshDailyNewsTopics({ force: true })` before posting, and log results.  
- Update `README.md` and `.env` example entries to document new `NEWS_*` configuration variables and the new `newsTopics.js` file in the project structure.  

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f9de87288330bcbdfa4ad9667f79)