### PR TITLE
Integrate news/trend-driven topics into Alkimo text generator and scheduler

### DIFF
--- a/generateText.js
+++ b/generateText.js
@@ -1,8 +1,8 @@
 // --------------------------------------------------------
-// generateText.js  •  Joe Edition  (v2 – 298‑char safety)
-// Generates funny posts & replies for the Joe Bluesky bot
+// generateText.js  •  Alkimo Edition
+// Generates concise posts & replies for the Alkimo Bluesky bot
 // using DeepSeek (priority) or OpenAI (fallback)
-// ▸ Bluesky hard limit ≈ 300 char → we enforce 298 to stay safe
+// ▸ Bluesky hard limit ≈ 300 char → we keep posts short to stay safe
 // --------------------------------------------------------
 
 import axios from 'axios'
@@ -28,6 +28,53 @@ const API_URL = provider === 'deepseek'
 
 const MODEL = provider === 'deepseek' ? 'deepseek-v4-flash' : 'gpt-3.5-turbo';
 
+const NEWS_RSS_URL = process.env.NEWS_RSS_URL || 'https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en';
+const NEWS_TIMEOUT_MS = Number(process.env.NEWS_TIMEOUT_MS || 8000);
+
+function decodeHtmlEntities(text = '') {
+  const entities = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' '
+  };
+
+  return text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, entity) => {
+    if (entity.startsWith('#x')) return String.fromCodePoint(parseInt(entity.slice(2), 16));
+    if (entity.startsWith('#')) return String.fromCodePoint(parseInt(entity.slice(1), 10));
+    return entities[entity] || match;
+  });
+}
+
+function stripNewsSource(title) {
+  // Google News titles usually end with \" - Source\". Keep the topic, remove the outlet.
+  return title.replace(/\s+-\s+[^-]+$/u, '').trim();
+}
+
+function extractRssItemTitles(xml = '') {
+  return [...xml.matchAll(/<item>[\s\S]*?<title><!\[CDATA\[(.*?)\]\]><\/title>[\s\S]*?<\/item>/g)]
+    .map(match => stripNewsSource(decodeHtmlEntities(match[1]).replace(/\s+/g, ' ')))
+    .filter(Boolean);
+}
+
+async function fetchCurrentNewsTopics(limit = 6) {
+  try {
+    const { data } = await axios.get(NEWS_RSS_URL, {
+      timeout: NEWS_TIMEOUT_MS,
+      headers: {
+        'User-Agent': 'AlkimoBlueBot/1.0 (+https://alkimo.ai)'
+      }
+    });
+
+    const titles = extractRssItemTitles(data);
+    return Array.from(new Set(titles)).slice(0, limit);
+  } catch (error) {
+    console.warn('[News] Impossible de récupérer les sujets d’actualité, fallback sur les thèmes evergreen :', error.message);
+    return [];
+  }
+}
 
 // ---------------------------------------------------------------------
 async function callGeminiApi(messages, maxTokens = 30) {
@@ -68,8 +115,8 @@ async function callChatApi(messages, maxTokens) {
 const SYSTEM_PROMPT = `You are Alkimo, a benevolent and pragmatic AI assistant designed for entrepreneurs, students, and creators. Your messages must be helpful, practical, and concise.
 Your style is:
 - Direct and clear (optimized for quick mobile reading).
-- Inspiring and focused on local technological solutions.
-- Grounded in real-world product and business use cases.
+- Inspiring and able to react to general current events, not only tech news.
+- Grounded in real-world product, business, education, and everyday use cases.
 - Professional yet approachable.
 You also promote the Alkimo Affiliate Program: partners earn 30% commission on €3.99 subs and 25% on €2.99 subs. Payouts from €10 via Stripe Connect. It's a great way for students and creators to earn while sharing a useful tool.
 Avoid clichés and useless emojis.`
@@ -83,43 +130,42 @@ Avoid clichés and useless emojis.`
  * Génère un texte pour un post "trombone" (paperclip) en mode dessin, vie à la plage, retraite, etc.
  * @returns {Promise<string>}
  */
-export async function generateTrombonePostText() {
-  // Liste de thèmes variés pour un développeur blockchain français cherchant à contribuer à des projets
-  // Thèmes adaptés à la première personne :
-  const topics = [
-    "Hot take: indie builders are shipping faster than ever",
+export async function generateTrombonePostText(externalCurrentTopics = []) {
+  const currentNewsTopics = externalCurrentTopics.length > 0 ? externalCurrentTopics : await fetchCurrentNewsTopics();
+  // Thèmes de secours variés : actualité générale, société, économie, éducation, tech et business.
+  const evergreenTopics = [
+    "How to stay productive when the news cycle is chaotic",
+    "What global headlines mean for small businesses",
+    "The one habit students need when news moves fast",
+    "How creators can turn current events into useful lessons",
+    "Why entrepreneurs should track news beyond their industry",
+    "How to verify a viral headline before sharing it",
+    "What economic uncertainty teaches builders",
+    "Why education matters during major world events",
+    "How local communities can respond to global changes",
+    "The practical side of staying informed without doomscrolling",
+    "How founders can separate signal from noise in the news",
     "3 practical AI hacks every founder can apply this week",
-    "What actually goes viral in tech communities",
-    "How AI can boost small businesses",
-    "Benefits of AI automation for everyday workflows",
-    "The future of tech: AI agents that actually work",
     "How Alkimo helps students study more effectively",
-    "Entrepreneurship in the AI era: opportunities everywhere",
-    "AI for smarter productivity and focus",
-    "Building with natural language: the new no-code",
-    "Alkimo: the assistant that gets things done",
-    "Developing tech solutions that just work",
-    "Tech vibes from builders worldwide",
-    "Innovating with AI at the frontier",
-    "How startups are rewriting the AI playbook",
+    "How AI can help summarize complex public issues",
     "AI bias: why diverse training data matters more than ever",
-    "The hidden cost of AI automation nobody talks about",
     "When AI hallucinates: how to spot and verify generated content",
-    "Privacy in the AI era: what users actually need to know",
-    "Job displacement vs job creation: the real AI debate",
-    "Why transparency in AI systems should be non-negotiable",
     "Join the Alkimo Affiliate Program: earn 30% commission by sharing AI power",
     "Monetize your network: become an Alkimo partner today",
     "Helping the community grow with the Alkimo affiliate rewards"
   ];
+  const topics = currentNewsTopics.length > 0 ? currentNewsTopics : evergreenTopics;
   const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+  const topicContext = currentNewsTopics.length > 0
+    ? `Current news topic: ${randomTopic}\nUse it as context, but do not invent facts beyond this headline. This can be politics, economy, culture, society, science, sports, weather, or tech. Keep Alkimo's personality: practical, benevolent, concise, and useful for entrepreneurs, students, and creators.`
+    : randomTopic;
   // 40% posts très courts, 60% posts moyens/longs
   const isShort = Math.random() < 0.8;
   let userPrompt;
   if (isShort) {
-    userPrompt = `${randomTopic}\nWrite a very short, punchy, and viral one-liner for Alkimo. It MUST be extremely short (1 line, max 12 words) and include a strong hook (surprise, bold claim, or challenge). Focus on AI productivity and tech empowerment. If the topic is about AI risks or ethics, be factual and constructive, not alarmist. Mainly in English. No emoji, no markdown.`;
+    userPrompt = `${topicContext}\nWrite a very short, punchy, and viral one-liner for Alkimo. It MUST be extremely short (1 line, max 12 words) and include a strong hook (surprise, bold claim, or challenge). React to the general news topic with one useful takeaway for work, study, decisions, or daily life. If the topic is sensitive, be respectful, factual, and constructive, not alarmist. Mainly in English. No emoji, no markdown.`;
   } else {
-    userPrompt = `${randomTopic}\nWrite a short original VIRAL post for Alkimo, an AI assistant (max 280 chars). Start with a strong hook in the first 6 words, include one concrete insight or micro-tip, and end with a soft call-to-action question. If the topic is about AI risks or ethics, be balanced, factual, and constructive — never alarmist. Use plain text, mainly in English. No markdown, no emojis.`;
+    userPrompt = `${topicContext}\nWrite a short original VIRAL post for Alkimo, an AI assistant (max 280 chars). Start with a strong hook in the first 6 words, connect the current topic to one concrete insight or micro-tip, and end with a soft call-to-action question. If the topic is sensitive, be balanced, factual, and constructive — never alarmist. Use plain text, mainly in English. No markdown, no emojis.`;
   }
   const messages = [
     { role: 'system', content: SYSTEM_PROMPT },
@@ -133,17 +179,24 @@ export async function generateTrombonePostText() {
   return text.trim();
 }
 
-export async function generatePostText() {
-  // Liste de topics/moods pour varier les posts - maintenant avec expertise économique/tech et humour
-  // Topics adaptés à la première personne :
-  const topics = [
+export async function generatePostText(externalCurrentTopics = []) {
+  const currentNewsTopics = externalCurrentTopics.length > 0 ? externalCurrentTopics : await fetchCurrentNewsTopics();
+  // Thèmes de secours variés : actualité générale, société, économie, éducation, tech et business.
+  const evergreenTopics = [
+    "How to stay useful while the world is changing fast",
+    "What today's headlines can teach entrepreneurs",
+    "Why students should learn to summarize complex news",
+    "How creators can explain current events responsibly",
+    "Turning a noisy news cycle into one clear action",
+    "How small teams can adapt to economic changes",
+    "Why local context matters in global events",
+    "How to verify breaking news before making decisions",
+    "The cost of reacting too fast to viral headlines",
+    "What leaders should do when uncertainty rises",
     "Alkimo: simplifying access to information",
-    "AI is no longer a luxury, it's a development tool",
     "Why AI assistants are a game-changer for modern teams",
     "Alkimo: fast, reliable, ready when you are",
-    "The future of work is being written with AI",
     "Boost your productivity with the Alkimo assistant",
-    "Innovation through smart automation",
     "Alkimo: AI that talks your language",
     "Supporting entrepreneurs in their growth journey",
     "AI as an educational lever for everyone",
@@ -158,14 +211,18 @@ export async function generatePostText() {
     "30% commission for every new Alkimo subscriber you refer"
   ];
   // Choix aléatoire d'un topic
+  const topics = currentNewsTopics.length > 0 ? currentNewsTopics : evergreenTopics;
   const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+  const topicContext = currentNewsTopics.length > 0
+    ? `Current news topic: ${randomTopic}\nUse it as context, but do not invent facts beyond this headline. This can be politics, economy, culture, society, science, sports, weather, or tech. Keep Alkimo's personality: practical, benevolent, concise, and useful for entrepreneurs, students, and creators.`
+    : randomTopic;
   // Tirage aléatoire pour la longueur du post (80% court, 20% moyen/long)
   const isShort = Math.random() < 0.5;
   let userPrompt;
   if (isShort) {
-    userPrompt = `${randomTopic}\nWrite a very short, direct, viral thought from Alkimo AI about tech growth. Max 12 words with a bold hook. If the topic is about AI risks or ethics, be factual and constructive, not alarmist. Mainly in English. No markdown, no emojis.`;
+    userPrompt = `${topicContext}\nWrite a very short, direct, viral thought from Alkimo AI about the current news topic. Max 12 words with a bold hook. Turn the news into a useful action without sounding like a news wire. If the topic is sensitive, be factual and constructive, not alarmist. Mainly in English. No markdown, no emojis.`;
   } else {
-    userPrompt = `${randomTopic}\nWrite an inspiring and viral post from Alkimo about how AI is transforming everyday productivity. Use a sharp hook, one actionable insight, and a closing question to trigger replies. If the topic is about AI risks or ethics, be balanced, factual, and constructive — never alarmist. Max 280 chars. Use plain text, mainly in English. No markdown, no emojis.`;
+    userPrompt = `${topicContext}\nWrite an inspiring and viral post from Alkimo about the current news topic. Use a sharp hook, one actionable insight tied to the topic, and a closing question to trigger replies. If the topic is sensitive, be balanced, factual, and constructive — never alarmist. Max 280 chars. Use plain text, mainly in English. No markdown, no emojis.`;
   }
   const messages = [
     {

--- a/scheduler.js
+++ b/scheduler.js
@@ -24,6 +24,22 @@ function nextHour(hour) {
 function inMinutes(minutes) {
   return new Date(Date.now() + minutes * 60 * 1000);
 }
+
+async function fetchTrendingTopics(limit = 6) {
+  try {
+    const res = await agent.app.bsky.unspecced.getTrendingTopics({
+      viewer: agent.session?.did,
+      limit
+    });
+    const topics = [...(res.data.topics || []), ...(res.data.suggested || [])]
+      .map(topic => topic.displayName || topic.topic)
+      .filter(Boolean);
+    return Array.from(new Set(topics)).slice(0, limit);
+  } catch (error) {
+    console.warn('[Bluesky][Trends] Impossible de récupérer les sujets tendance, fallback sur RSS/evergreen :', error?.response?.data || error.message);
+    return [];
+  }
+}
 console.log('=== Alkimo Bot Scheduler started! ===');
 // Initialise la base de données locale pour stocker l'état des jobs
 const jobs = new BlazeJob({ dbPath: './alkimo-jobs.db' });
@@ -37,7 +53,8 @@ for (const hour of postTextHours) {
     try {
       console.log(`[BlazeJob] [START] Job texte Alkimo ${hour}h`);
       await initBluesky();
-      const text = await generateTrombonePostText();
+      const trendingTopics = await fetchTrendingTopics();
+      const text = await generateTrombonePostText(trendingTopics);
       await agent.post({ text });
       console.log(`[BlazeJob][PostTexte] Texte posté à ${hour}h :`, text);
       console.log(`[BlazeJob] [END] Job texte Alkimo ${hour}h`);


### PR DESCRIPTION
### Motivation
- Make Alkimo posts react to current events and trending topics to increase relevance and engagement. 
- Provide multiple topic sources with robust fallbacks so generation doesn't fail when APIs are unavailable. 
- Tune prompts and persona to be concise, practical, and safe when handling sensitive news.

### Description
- Added RSS-based news fetching in `generateText.js` with `NEWS_RSS_URL`/`NEWS_TIMEOUT_MS`, `fetchCurrentNewsTopics`, `decodeHtmlEntities`, `extractRssItemTitles`, and `stripNewsSource` helpers to extract and clean headlines. 
- Updated `generateTrombonePostText` and `generatePostText` to accept `externalCurrentTopics`, use fetched news topics (or evergreen fallbacks), and include a `topicContext` instruction in the user prompt to avoid inventing facts. 
- Revised `SYSTEM_PROMPT` to the Alkimo persona and adjusted prompt text/cleanup logic and length constraints; expanded evergreen topic lists and affiliate messaging. 
- Added `fetchTrendingTopics` in `scheduler.js` to query Bluesky trends and pass them into post generation for scheduled jobs, with error handling and fallback to RSS/evergreen topics.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30fa4135588330bbf5502657343048)