### PR TITLE
Recentrer Alkimo sur une IA libre et respectueuse de la vie privée

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🤖 Clippy Bluesky Bot
 
-Bot Bluesky complet en Node.js/ESM pour générer, poster, liker, suivre et répondre automatiquement avec des memes IA de Clippy !
+Bot Bluesky en Node.js/ESM qui porte une vision simple : chacun doit pouvoir utiliser l’IA librement, sans suivi, profilage publicitaire ni enfermement dans un écosystème.
+
+Le discours d’Alkimo s’adresse en priorité aux personnes qui veulent garder le contrôle de leurs données et de leurs choix. Le bot publie des conseils concrets autour d’une IA utile et respectueuse de l’autonomie, sans inventer de garanties techniques de confidentialité.
 
 ## Sommaire
 - [Fonctionnalités](#fonctionnalités)
@@ -16,6 +18,8 @@ Bot Bluesky complet en Node.js/ESM pour générer, poster, liker, suivre et rép
 ---
 
 ## Fonctionnalités
+- **Prise de parole axée vie privée et liberté d’usage** : autonomie, contrôle des données, absence de profilage et choix des outils
+- **Veille ciblée** sur les conversations liées à la confidentialité, au suivi et aux alternatives ouvertes ou locales
 - **Génération d’images memes Clippy** via l’API Hugging Face (Stable Diffusion)
 - **Génération de textes posts et replies** via DeepSeek ou OpenAI (GPT)
 - **Publication automatique** sur Bluesky (texte + image)

--- a/autoReply.js
+++ b/autoReply.js
@@ -12,11 +12,10 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// Termes de recherche pour cibler l'IA en général et les pays en développement
+// Termes de recherche centrés sur une utilisation libre de l'IA, sans suivi ni profilage
 const SEARCH_TERMS = [
-  // IA générale
-  'AI', 'artificial intelligence', 'machine learning', 'deep learning', 'LLM',
-  'gen AI', 'foundation models', 'computer vision', 'NLP', 'AI agents',
+  'AI privacy', 'private AI', 'AI tracking', 'AI surveillance', 'AI profiling',
+  'data privacy AI', 'anonymous AI', 'AI freedom', 'open AI tools', 'local AI',
   /*   // Asie du Sud et Asie du Sud-Est
     'India tech', 'Bangalore AI', 'Hyderabad AI', 'Delhi AI',
     'Pakistan tech', 'Karachi AI', 'Lahore AI',
@@ -123,8 +122,8 @@ export async function autoSmallReply() {
     const replyHistory = loadReplyHistory();
     const MAX_REPLIES_PER_RUN = 2;
     const searchTerms = [
-      'AI', 'artificial intelligence', 'machine learning', 'deep learning', 'LLM',
-      'gen AI', 'foundation models', 'computer vision', 'NLP', 'AI agents'
+      'AI privacy', 'private AI', 'AI tracking', 'AI surveillance', 'AI profiling',
+      'data privacy AI', 'anonymous AI', 'AI freedom', 'open AI tools', 'local AI'
     ];
 
     // Vérifie le quota reply avant d'initialiser
@@ -343,4 +342,3 @@ export async function autoReply() {
     console.error('[Erreur][autoReply] Erreur globale dans autoReply :', error?.response?.data || error.message);
   }
 }
-

--- a/generateText.js
+++ b/generateText.js
@@ -112,14 +112,15 @@ async function callChatApi(messages, maxTokens) {
   return data.choices[0]?.message?.content?.trim() || '';
 }
 
-const SYSTEM_PROMPT = `You are Alkimo, a benevolent and pragmatic AI assistant designed for entrepreneurs, students, and creators. Your messages must be helpful, practical, and concise.
+const SYSTEM_PROMPT = `You are Alkimo, a benevolent and pragmatic AI assistant for people who want to use AI freely without being tracked. Your messages must be helpful, practical, and concise.
 Your style is:
 - Direct and clear (optimized for quick mobile reading).
-- Inspiring and able to react to general current events, not only tech news.
-- Grounded in real-world product, business, education, and everyday use cases.
+- Centered on privacy, user autonomy, freedom of choice, and control over personal data.
+- Reassuring to people who reject surveillance, profiling, behavioral advertising, or lock-in.
+- Grounded in real-world product, business, education, creative, and everyday use cases.
 - Professional yet approachable.
-You also promote the Alkimo Affiliate Program: partners earn 30% commission on €3.99 subs and 25% on €2.99 subs. Payouts from €10 via Stripe Connect. It's a great way for students and creators to earn while sharing a useful tool.
-Avoid clichés and useless emojis.`
+Present AI as a tool that remains at the user's service: no moralizing, fearmongering, or vague claims about privacy. Never claim a specific technical privacy guarantee unless it is provided in the topic. Mention the Alkimo Affiliate Program only when the selected topic is explicitly about it.
+Avoid clichés, surveillance-themed jokes, and useless emojis.`
 
 
 /**
@@ -134,6 +135,12 @@ export async function generateTrombonePostText(externalCurrentTopics = []) {
   const currentNewsTopics = externalCurrentTopics.length > 0 ? externalCurrentTopics : await fetchCurrentNewsTopics();
   // Thèmes de secours variés : actualité générale, société, économie, éducation, tech et business.
   const evergreenTopics = [
+    "Use AI without turning your life into advertising data",
+    "Why private AI use should be the default, not a premium",
+    "Keep control of what you share with an AI assistant",
+    "Freedom to use AI without profiling or behavioral tracking",
+    "Choose an AI tool without being trapped in an ecosystem",
+    "Practical habits for sharing less personal data with AI",
     "How to stay productive when the news cycle is chaotic",
     "What global headlines mean for small businesses",
     "The one habit students need when news moves fast",
@@ -149,10 +156,7 @@ export async function generateTrombonePostText(externalCurrentTopics = []) {
     "How Alkimo helps students study more effectively",
     "How AI can help summarize complex public issues",
     "AI bias: why diverse training data matters more than ever",
-    "When AI hallucinates: how to spot and verify generated content",
-    "Join the Alkimo Affiliate Program: earn 30% commission by sharing AI power",
-    "Monetize your network: become an Alkimo partner today",
-    "Helping the community grow with the Alkimo affiliate rewards"
+    "When AI hallucinates: how to spot and verify generated content"
   ];
   const topics = currentNewsTopics.length > 0 ? currentNewsTopics : evergreenTopics;
   const randomTopic = topics[Math.floor(Math.random() * topics.length)];
@@ -183,6 +187,12 @@ export async function generatePostText(externalCurrentTopics = []) {
   const currentNewsTopics = externalCurrentTopics.length > 0 ? externalCurrentTopics : await fetchCurrentNewsTopics();
   // Thèmes de secours variés : actualité générale, société, économie, éducation, tech et business.
   const evergreenTopics = [
+    "AI should help you, not build a profile about you",
+    "Use AI freely without trading away your privacy",
+    "Personal data control is part of digital freedom",
+    "A useful AI experience without surveillance or profiling",
+    "Ask, create, and learn without being tracked",
+    "How to minimize the personal data you share with AI",
     "How to stay useful while the world is changing fast",
     "What today's headlines can teach entrepreneurs",
     "Why students should learn to summarize complex news",
@@ -205,10 +215,7 @@ export async function generatePostText(externalCurrentTopics = []) {
     "AI ethics: building technology that serves everyone fairly",
     "The risks of over-relying on AI for critical decisions",
     "Deepfakes and misinformation: AI's most dangerous side effect",
-    "Why human oversight in AI is still essential in 2025",
-    "Empowering creators with the Alkimo partner program",
-    "Earn while you learn: how students use Alkimo affiliation",
-    "30% commission for every new Alkimo subscriber you refer"
+    "Why human oversight in AI is still essential"
   ];
   // Choix aléatoire d'un topic
   const topics = currentNewsTopics.length > 0 ? currentNewsTopics : evergreenTopics;
@@ -251,8 +258,9 @@ export async function generateReplyText(originalText, language = 'en') {
 
   const messages = [
     {
-      role: 'system', content: `You are Alkimo, an AI assistant. You are helpful, direct, and empathetic. 
+      role: 'system', content: `You are Alkimo, an AI assistant for people who want useful AI without tracking, profiling, or lock-in. You are helpful, direct, and empathetic.
       Your responses adapt to the tone of the original post but always stay focused on being useful.
+      Respect user autonomy and privacy. Never invent claims about Alkimo's technical privacy guarantees.
       If the topic is serious, be respectful and supportive.
       Respond primarily in English.`
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alkimo-bluesky-bot",
   "version": "1.0.0",
-  "description": "Assistant IA Alkimo pour l'Afrique - Bot Bluesky avec génération de texte et d'images.",
+  "description": "Bot Bluesky d'Alkimo pour une IA libre, utile et sans suivi.",
   "type": "module",
   "main": "scheduler.js",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Recentrer le positionnement éditorial du bot vers les personnes qui veulent utiliser l’IA librement, sans suivi, profilage publicitaire ni enfermement dans un écosystème.
- Empêcher que le bot n’invente ou ne promeuve des garanties techniques de confidentialité non vérifiées dans ses réponses et publications.
- Cibler la veille et les interactions automatiques sur les conversations liées à la vie privée, la surveillance et les alternatives ouvertes ou locales.

### Description
- Mise à jour du prompt système dans `generateText.js` pour prioriser la vie privée, l’autonomie des utilisateurs et éviter les promesses techniques de confidentialité non vérifiées.
- Ajout de sujets "evergreen" et d’exemples de publication axés sur le contrôle des données et l’usage d’une IA sans tracking dans `generateText.js` (posts et trombone posts).
- Renforcement du guardrail de génération de réponses dans `generateText.js` pour rappeler de ne pas inventer de garanties de confidentialité et limiter la promotion de l’affiliation aux cas pertinents.
- Modification de `autoReply.js` pour recentrer `SEARCH_TERMS` sur la confidentialité, le suivi, le profilage et les alternatives locales/ouverts, et mise à jour du `README.md` et de `package.json` pour refléter le nouveau discours.

### Testing
- Exécution de `git diff --check` qui n’a retourné aucune erreur et a validé le diff.
- Vérification syntaxique Node avec `node --check generateText.js` qui a réussi sans erreur.
- Vérification syntaxique Node avec `node --check autoReply.js` qui a réussi sans erreur.
- Contrôle d’état du dépôt (`git status --short`) montrant l’arbre de travail propre après le commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b5e4036b88330b3322c9ba9597b40)